### PR TITLE
Added Discord Server to the Issue Templates Configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,9 @@ contact_links:
   - name: Codidact Community Forum
     url: https://forum.codidact.org/
     about: Please ask and answer questions here.
+  - name: Codidact Discord Server
+    url: https://discord.gg/WZ7aTst
+    about: Join us on Discord for more on-the-go discussion.
+  - name: Codidact Project Wiki
+    url: https://github.com/codidact/docs/wiki
+    about: For more in-depth information please use our wiki.


### PR DESCRIPTION
I also added the Wiki to the configuration file, and I used
the language from the Codidact landing page, as I figured it
would be best to use language that has already been vetted
by the team.

This commit fixes issue #21